### PR TITLE
Fixes CASMPET-5011: update image refs

### DIFF
--- a/.github/workflows/charts-lint-test-scan-cron.yml
+++ b/.github/workflows/charts-lint-test-scan-cron.yml
@@ -1,0 +1,16 @@
+name: Cron Lint, test, and scan Helm charts
+on:
+  schedule:
+    - cron: "16 3 * * *"
+  workflow_dispatch:
+jobs:
+  lint-test-scan:
+    uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
+    with:
+      ct-config: |
+        chart-dirs:
+          - kubernetes
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
+      scan-image-snyk-args: "--severity-threshold=high"
+    secrets:
+      snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -1,0 +1,21 @@
+name: Lint, test, and scan Helm charts
+on:
+  pull_request:
+    branches:
+      - master
+      - release/**
+  workflow_dispatch:
+jobs:
+  lint-test-scan:
+    uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
+    with:
+      scan-image-snyk-args: "--severity-threshold=high"
+      lint-charts: ${{ github.event_name == 'pull_request' }}
+      ct-config: |
+        chart-dirs:
+          - kubernetes
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
+      test-charts: false
+      scan-images: false
+    secrets:
+      snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/kubernetes/.snyk
+++ b/kubernetes/.snyk
@@ -1,0 +1,15 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-K8S-44:
+    - '*':
+        reason: This is only general advice to grant fewer permissions.
+        expires: 2041-12-01T00:00:00.000Z
+        created: 2021-11-09T16:32:42.642Z
+  SNYK-CC-K8S-47:
+    - '*':
+        reason: This is only general advice to grant fewer permissions.
+        expires: 2041-12-01T00:00:00.000Z
+        created: 2021-11-09T16:32:45.654Z
+patch: {}

--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -1,6 +1,19 @@
-apiVersion: v1
-appVersion: 0.15.0
+apiVersion: v2
+version: 0.7.0
 description: An extension of the official kafka-operator helm chart
 name: cray-kafka-operator
-home: "cloud/cray-charts"
-version: 0.4.1
+keywords:
+  - kafka-operator
+home: https://github.com/Cray-HPE/cray-kafka-operator
+sources:
+  - https://github.com/strimzi/strimzi-kafka-operator
+maintainers:
+  - name: brantk-hpe
+dependencies:
+  - name: strimzi-kafka-operator
+    repository: https://strimzi.io/charts/
+    version: 0.15.0
+icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
+appVersion: 0.15.0
+annotations:
+  artifacthub.io/license: MIT

--- a/kubernetes/cray-kafka-operator/requirements.lock
+++ b/kubernetes/cray-kafka-operator/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: strimzi-kafka-operator
-  repository: https://strimzi.io/charts/
-  version: 0.15.0
-digest: sha256:f834e8308d5dfabc32c94e8257aeaa85c08d045d278a81d1a3e0c189185a6732
-generated: "2020-02-26T19:40:55.653697-06:00"

--- a/kubernetes/cray-kafka-operator/requirements.yaml
+++ b/kubernetes/cray-kafka-operator/requirements.yaml
@@ -1,5 +1,0 @@
----
-dependencies:
-  - name: strimzi-kafka-operator
-    version: "0.15.0"
-    repository: "@strimzi"

--- a/kubernetes/cray-kafka-operator/values.yaml
+++ b/kubernetes/cray-kafka-operator/values.yaml
@@ -1,6 +1,10 @@
 # Default values for cray-kafka-operator.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+image:
+  repository: artifactory.algol60.net/artifactory/csm-docker/stable/quay.io/strimzi/operator
+  # tag defaults to chart appVersion
+  pullPolicy: IfNotPresent
 
 strimzi-kafka-operator:
   watchNamespaces:


### PR DESCRIPTION
## Summary and Scope

Updated the image repo to point to the algol60 repo. Increased the minor version from 0.4.x to 0.7.0 to 
leave room for 1.0 or 1.1 patches.

## Issues and Related PRs

* Resolves [CASMPET-5011](https://connect.us.cray.com/jira/browse/CASMPET-5011)

## Testing

wasp

### Tested on:

  * `wasp`

### Test description:

Upgraded cray-kafka-operator helm chart, and verified the strimzi-cluster-operator pod was able to
pull the strimzi/operator image successfully from algol60 repo. Logs showed no issues.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

