### PR TITLE
Add images required by operator

### DIFF
--- a/.github/workflows/charts-lint-test-scan-cron.yml
+++ b/.github/workflows/charts-lint-test-scan-cron.yml
@@ -7,9 +7,6 @@ jobs:
   lint-test-scan:
     uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
     with:
-      ct-config: |
-        chart-dirs:
-          - kubernetes
       scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
       scan-image-snyk-args: "--severity-threshold=high"
     secrets:

--- a/.github/workflows/charts-lint-test-scan.yml
+++ b/.github/workflows/charts-lint-test-scan.yml
@@ -9,13 +9,10 @@ jobs:
   lint-test-scan:
     uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
     with:
-      scan-image-snyk-args: "--severity-threshold=high"
       lint-charts: ${{ github.event_name == 'pull_request' }}
-      ct-config: |
-        chart-dirs:
-          - kubernetes
-      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
       test-charts: false
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
       scan-images: false
+      scan-image-snyk-args: "--severity-threshold=high"
     secrets:
       snyk-token: ${{ secrets.SNYK_TOKEN }}

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -14,24 +14,22 @@ pipeline {
         NAME = "cray-kafka-operator"
         DESCRIPTION = "Deploys the Kafka operator."
         IS_STABLE = getBuildIsStable()
-        CHART_VERSION = getChartVersion(name: env.NAME, isStable: env.IS_STABLE)
     }
 
     stages {
         stage("Build") {
-            parallel {
-                stage('Chart') {
-                    steps {
-                        sh "make chart"
-                    }
-                }
+            environment {
+                CHART_VERSIONS = getChartVersion(name: "cray-kafka-operator", chartDirectory: "kubernetes", isStable: env.IS_STABLE)
+            }
+            steps {
+                sh "make"
             }
         }
 
         stage('Publish ') {
             steps {
                 script {
-                    publishCsmHelmCharts(component: env.NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", isStable: env.IS_STABLE)
+                    publishCsmHelmCharts(component: env.NAME, chartsPath: "${WORKSPACE}/packages", isStable: env.IS_STABLE)
                 }
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,65 @@
-NAME ?= cray-kafka-operator
-CHART_PATH ?= kubernetes
-CHART_VERSION ?= local
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 
-HELM_UNITTEST_IMAGE ?= quintush/helm-unittest:3.3.0-0.2.5
+CHART_METADATA_IMAGE ?= artifactory.algol60.net/csm-docker/stable/chart-metadata
+YQ_IMAGE ?= artifactory.algol60.net/docker.io/mikefarah/yq:4
+HELM_IMAGE ?= artifactory.algol60.net/docker.io/alpine/helm:3.7.1
+HELM_UNITTEST_IMAGE ?= artifactory.algol60.net/docker.io/quintush/helm-unittest
+HELM_DOCS_IMAGE ?= artifactory.algol60.net/docker.io/jnorwood/helm-docs:v1.5.0
 
-all : chart
-chart: chart_setup chart_package chart_test
+all: lint dep-up test package
 
+helm:
+	docker run --rm \
+		--user $(shell id -u):$(shell id -g) \
+		--mount type=bind,src="$(shell pwd)",dst=/src \
+		-w /src \
+		-e HELM_CACHE_HOME=/src/.helm/cache \
+		-e HELM_CONFIG_HOME=/src/.helm/config \
+		-e HELM_DATA_HOME=/src/.helm/data \
+		$(HELM_IMAGE) \
+		$(CMD)
 
-chart_setup:
-		mkdir -p ${CHART_PATH}/.packaged
+lint:
+	CMD="lint kubernetes/cray-kafka-operator" $(MAKE) helm
 
-chart_package:
-		helm dep up ${CHART_PATH}/${NAME}
-		helm package ${CHART_PATH}/${NAME} -d ${CHART_PATH}/.packaged --version ${CHART_VERSION}
+dep-up:
+	CMD="dep up kubernetes/cray-kafka-operator" $(MAKE) helm
 
-chart_test:
-		helm lint "${CHART_PATH}/${NAME}"
-		docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${NAME}
+test:
+	docker run --rm \
+		-v ${PWD}/kubernetes:/apps \
+		${HELM_UNITTEST_IMAGE} -3 \
+		cray-kafka-operator
+
+package:
+ifdef CHART_VERSIONS
+	CMD="package kubernetes/cray-kafka-operator --version $(word 1, $(CHART_VERSIONS)) -d packages" $(MAKE) helm
+else
+	CMD="package kubernetes/* -d packages" $(MAKE) helm
+endif
+
+extracted-images:
+	CMD="template release $(CHART) --dry-run --replace --dependency-update" $(MAKE) -s helm \
+	| docker run --rm -i $(YQ_IMAGE) e -N '.. | .image? | select(.)' - | grep -vE '^(image: null|type: string)$$'
+
+annotated-images:
+	CMD="show chart $(CHART)" $(MAKE) -s helm \
+	| docker run --rm -i $(YQ_IMAGE) e -N '.annotations."artifacthub.io/images"' - \
+	| docker run --rm -i $(YQ_IMAGE) e -N '.. | .image? | select(.)' -
+
+images:
+	CHART=kubernetes/cray-kafka-operator $(MAKE) -s extracted-images annotated-images | sort -u
+
+snyk:
+	$(MAKE) -s images | xargs --verbose -n 1 snyk container test
+
+gen-docs:
+	docker run --rm \
+		--user $(shell id -u):$(shell id -g) \
+		--mount type=bind,src="$(shell pwd)",dst=/src \
+		-w /src \
+		$(HELM_DOCS_IMAGE) \
+		helm-docs --chart-search-root=kubernetes
+
+clean:
+	$(RM) -r .helm packages kubernetes/cray-kafka-operator/charts

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,4 @@
+chart-dirs:
+  - kubernetes
+chart-repos:
+  - strimzi=https://strimzi.io/charts/

--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -16,4 +16,15 @@ dependencies:
 icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
 appVersion: 0.15.0
 annotations:
+  artifacthub.io/images: |-
+    - name: operator
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/operator:0.15.0
+    - name: kafka-bridge
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka-bridge:0.15.0
+    - name: kafka-2.3.1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.1
+    - name: kafka-2.3.0
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.0
+    - name: kafka-2.2.1
+      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.2.1
   artifacthub.io/license: MIT

--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.7.0
+version: 0.7.1
 description: An extension of the official kafka-operator helm chart
 name: cray-kafka-operator
 keywords:

--- a/kubernetes/cray-kafka-operator/values.yaml
+++ b/kubernetes/cray-kafka-operator/values.yaml
@@ -14,67 +14,67 @@ strimzi-kafka-operator:
 
   zookeeper:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka
       tagPrefix: 0.15.0
   kafka:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka
       tagPrefix: 0.15.0
   kafkaConnect:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka
       tagPrefix: 0.15.0
   kafkaConnects2i:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka
       tagPrefix: 0.15.0
   topicOperator:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: operator
       tag: 0.15.0
   userOperator:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: operator
       tag: 0.15.0
   kafkaInit:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: operator
       tag: 0.15.0
   tlsSidecarZookeeper:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka
       tagPrefix: 0.15.0
   tlsSidecarKafka:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka
       tagPrefix: 0.15.0
   tlsSidecarEntityOperator:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka
       tagPrefix: 0.15.0
   kafkaMirrorMaker:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka
       tagPrefix: 0.15.0
   kafkaBridge:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka-bridge
       tag: 0.15.0
   kafkaExporter:
     image:
-      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
       name: kafka
       tagPrefix: 0.15.0
 

--- a/kubernetes/cray-kafka-operator/values.yaml
+++ b/kubernetes/cray-kafka-operator/values.yaml
@@ -7,10 +7,77 @@ strimzi-kafka-operator:
     - sma
 
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi
+    repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
     name: operator
     tag: 0.15.0
     imagePullPolicy: IfNotPresent
+
+  zookeeper:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka
+      tagPrefix: 0.15.0
+  kafka:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka
+      tagPrefix: 0.15.0
+  kafkaConnect:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka
+      tagPrefix: 0.15.0
+  kafkaConnects2i:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka
+      tagPrefix: 0.15.0
+  topicOperator:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: operator
+      tag: 0.15.0
+  userOperator:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: operator
+      tag: 0.15.0
+  kafkaInit:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: operator
+      tag: 0.15.0
+  tlsSidecarZookeeper:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka
+      tagPrefix: 0.15.0
+  tlsSidecarKafka:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka
+      tagPrefix: 0.15.0
+  tlsSidecarEntityOperator:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka
+      tagPrefix: 0.15.0
+  kafkaMirrorMaker:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka
+      tagPrefix: 0.15.0
+  kafkaBridge:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka-bridge
+      tag: 0.15.0
+  kafkaExporter:
+    image:
+      respository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      name: kafka
+      tagPrefix: 0.15.0
+
 # Increase resources.limits.cpu to 8 to reduce cpu throttling
   resources:
     limits:


### PR DESCRIPTION
Fixes CASMPET-5011. Required by CASMPET-5020 so required Kafka images are available.

Snyk results since the workflow skips scanning images:

```
$ make snyk
make -s images | xargs --verbose -n 1 snyk container test
snyk container test artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka-bridge:0.15.0

Testing artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka-bridge:0.15.0...

Organization:      shasta-csm-oss
Package manager:   rpm
Project name:      docker-image|artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka-bridge
Docker image:      artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka-bridge:0.15.0
Platform:          linux/amd64
Base image:        centos:7
Licenses:          enabled

✔ Tested 164 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
snyk container test artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.2.1

Testing artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.2.1...

Organization:      shasta-csm-oss
Package manager:   rpm
Project name:      docker-image|artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka
Docker image:      artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.2.1
Platform:          linux/amd64
Base image:        centos:7
Licenses:          enabled

✔ Tested 178 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
snyk container test artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.0

Testing artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.0...

Organization:      shasta-csm-oss
Package manager:   rpm
Project name:      docker-image|artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka
Docker image:      artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.0
Platform:          linux/amd64
Base image:        centos:7
Licenses:          enabled

✔ Tested 178 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
snyk container test artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.1

Testing artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.1...

Organization:      shasta-csm-oss
Package manager:   rpm
Project name:      docker-image|artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka
Docker image:      artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.1
Platform:          linux/amd64
Base image:        centos:7
Licenses:          enabled

✔ Tested 178 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
snyk container test artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/operator:0.15.0

Testing artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/operator:0.15.0...

Organization:      shasta-csm-oss
Package manager:   rpm
Project name:      docker-image|artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/operator
Docker image:      artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/operator:0.15.0
Platform:          linux/amd64
Base image:        centos:7
Licenses:          enabled

✔ Tested 164 dependencies for known issues, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
```