### PR TITLE
CASMPET-5214 Add strimzi operator CVE-2021-44228 fix

### DIFF
--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.15.0
 description: An extension of the official kafka-operator helm chart
 name: cray-kafka-operator
 home: "cloud/cray-charts"
-version: 0.4.1
+version: 0.4.2

--- a/kubernetes/cray-kafka-operator/values.yaml
+++ b/kubernetes/cray-kafka-operator/values.yaml
@@ -6,6 +6,19 @@ strimzi-kafka-operator:
   watchNamespaces:
     - services
     - sma
+
+  image:
+    tag: 0.15.0-noJndiLookupClass
+  topicOperator:
+    image:
+      tag: 0.15.0-noJndiLookupClass
+  userOperator:
+    image:
+      tag: 0.15.0-noJndiLookupClass
+  kafkaInit:
+    image:
+      tag: 0.15.0-noJndiLookupClass
+
 # Increase resources.limits.cpu to 8 to reduce cpu throttling
   resources:
     limits:


### PR DESCRIPTION
## Summary and Scope

This updates the strimzi operator image to use the tag 0.15.0-noJndiLookupClass. This is a container with the jdnilookup.class removed, which works around CVE-2021-44228.

## Issues and Related PRs

* Resolves [CASMPET-5214](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5214) 

## Testing

Validated that the proper operators started running with the correct containers.
### Tested on:

  * Virtual Shasta

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
 - Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Needs further testing on a system with all products installed in order to verify everything works properly.


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

