### PR TITLE
CASMPET-5217 Update to strimzi 0.27.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2020] Hewlett Packard Enterprise Development LP
+(C) Copyright [2020,2022] Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 CHART_METADATA_IMAGE ?= artifactory.algol60.net/csm-docker/stable/chart-metadata
 YQ_IMAGE ?= artifactory.algol60.net/docker.io/mikefarah/yq:4

--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.7.1
+version: 1.0.0
 description: An extension of the official kafka-operator helm chart
 name: cray-kafka-operator
 keywords:
@@ -9,22 +9,23 @@ sources:
   - https://github.com/strimzi/strimzi-kafka-operator
 maintainers:
   - name: bo-quan
+  - name: kburns-hpe
 dependencies:
   - name: strimzi-kafka-operator
     repository: https://strimzi.io/charts/
-    version: 0.15.0
+    version: 0.27.0
 icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
-appVersion: 0.15.0
+appVersion: 0.27.0
 annotations:
   artifacthub.io/images: |-
     - name: operator
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/operator:0.15.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.27.0
     - name: kafka-bridge
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka-bridge:0.15.0
-    - name: kafka-2.3.1
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.1
-    - name: kafka-2.3.0
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.3.0
-    - name: kafka-2.2.1
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi/kafka:0.15.0-kafka-2.2.1
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka-bridge:0.21.2
+    - name: kafka-2.8.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.27.0-kafka-2.8.0
+    - name: kafka-2.8.1
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
+    - name: kafka-3.0.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
   artifacthub.io/license: MIT

--- a/kubernetes/cray-kafka-operator/values.yaml
+++ b/kubernetes/cray-kafka-operator/values.yaml
@@ -7,78 +7,92 @@ strimzi-kafka-operator:
     - sma
 
   image:
-    repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+    registry: artifactory.algol60.net
+    repository: csm-docker/stable/quay.io/strimzi
     name: operator
-    tag: 0.15.0
+    tag: 0.27.0
     imagePullPolicy: IfNotPresent
 
   zookeeper:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.15.0
+      tagPrefix: 0.27.0
   kafka:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.15.0
+      tagPrefix: 0.27.0
   kafkaConnect:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.15.0
+      tagPrefix: 0.27.0
   kafkaConnects2i:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.15.0
+      tagPrefix: 0.27.0
   topicOperator:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: operator
-      tag: 0.15.0
+      tag: 0.27.0
   userOperator:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: operator
-      tag: 0.15.0
+      tag: 0.27.0
   kafkaInit:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: operator
-      tag: 0.15.0
+      tag: 0.27.0
   tlsSidecarZookeeper:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.15.0
+      tagPrefix: 0.27.0
   tlsSidecarKafka:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.15.0
+      tagPrefix: 0.27.0
   tlsSidecarEntityOperator:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.15.0
+      tagPrefix: 0.27.0
   kafkaMirrorMaker:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.15.0
+      tagPrefix: 0.27.0
   kafkaBridge:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka-bridge
-      tag: 0.15.0
+      tag: 0.21.2
   kafkaExporter:
     image:
-      repository: artifactory.algol60.net/csm-docker/stable/docker.io/strimzi
+      registry: artifactory.algol60.net
+      repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.15.0
+      tagPrefix: 0.27.0
 
-# Increase resources.limits.cpu to 8 to reduce cpu throttling
+  # Increase resources.limits.cpu to 8 to reduce cpu throttling
   resources:
     limits:
       cpu: "8"


### PR DESCRIPTION
## Summary and Scope

Updates to use strimzi 0.27.0. This is being done to lower our CVE count and provide the proper CVE-2021-44228 fix.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5217](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5217)

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? N, this jumps kafka from 2.2 to 2.8. I don't have any knowledge of how we test to validate that kafka can deal with the upgrade properly. This will need to be done on a bare metal system.
- Was downgrade tested? N, this jumps kafka from 2.2 to 2.8. I don't have any knowledge of how we test to validate that kafka can deal with the downgrade properly. This will need to be done on a bare metal system.
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

This updates the strimzi CRD api from kafka.strimzi.io/v1alpha1 to kafka.strimzi.io/v1beta2. All charts that use this API will need to be updated. It will also bump us from Kafka 2.2.1 to 2.8.1, which will need additional testing as well.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

