### PR TITLE
CASMPET-5363 Switch to noJSM-chainsaw-kafka images

### DIFF
--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.15.0
 description: An extension of the official kafka-operator helm chart
 name: cray-kafka-operator
 home: "cloud/cray-charts"
-version: 0.4.2
+version: 0.5.0

--- a/kubernetes/cray-kafka-operator/values.yaml
+++ b/kubernetes/cray-kafka-operator/values.yaml
@@ -18,8 +18,35 @@ strimzi-kafka-operator:
   kafkaInit:
     image:
       tag: 0.15.0-noJndiLookupClass
+  zookeeper:
+    image:
+      tagPrefix: 0.15.0-noJSM-chainsaw
+  kafka:
+    image:
+      tagPrefix: 0.15.0-noJSM-chainsaw
+  kafkaConnect:
+    image:
+      tagPrefix: 0.15.0-noJSM-chainsaw
+  kafkaConnects2i:
+    image:
+      tagPrefix: 0.15.0-noJSM-chainsaw
+  tlsSidecarZookeeper:
+    image:
+      tagPrefix: 0.15.0-noJSM-chainsaw
+  tlsSidecarKafka:
+    image:
+      tagPrefix: 0.15.0-noJSM-chainsaw
+  tlsSidecarEntityOperator:
+    image:
+      tagPrefix: 0.15.0-noJSM-chainsaw
+  kafkaMirrorMaker:
+    image:
+      tagPrefix: 0.15.0-noJSM-chainsaw
+  kafkaExporter:
+    image:
+      tagPrefix: 0.15.0-noJSM-chainsaw
 
-# Increase resources.limits.cpu to 8 to reduce cpu throttling
+  # Increase resources.limits.cpu to 8 to reduce cpu throttling
   resources:
     limits:
       cpu: "8"


### PR DESCRIPTION
## Summary and Scope

This updates the operator to spin up kafka using the noJSM-chainsaw-kafka images that resolve a number of log4j CVEs.

## Issues and Related PRs

* Resolves [CASMPET-5363](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5363) 

## Testing

### Tested on:
  * Virtual Shasta

### Test description:

Validated the operator came up properly and that all the kafka pods were recreated with the new image.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

