### PR TITLE
CASMPET-5362 Update operator to 0.27.1

### DIFF
--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.0.0
+version: 1.1.0
 description: An extension of the official kafka-operator helm chart
 name: cray-kafka-operator
 keywords:
@@ -13,19 +13,19 @@ maintainers:
 dependencies:
   - name: strimzi-kafka-operator
     repository: https://strimzi.io/charts/
-    version: 0.27.0
+    version: 0.27.1
 icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
-appVersion: 0.27.0
+appVersion: 0.27.1
 annotations:
   artifacthub.io/images: |-
     - name: operator
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.27.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.27.1
     - name: kafka-bridge
       image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka-bridge:0.21.2
     - name: kafka-2.8.0
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.27.0-kafka-2.8.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.27.1-noJSM-chainsaw-kafka-2.8.0
     - name: kafka-2.8.1
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.27.1-noJSM-chainsaw-kafka-2.8.1
     - name: kafka-3.0.0
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.27.1-noJSM-chainsaw-kafka-3.0.0
   artifacthub.io/license: MIT

--- a/kubernetes/cray-kafka-operator/values.yaml
+++ b/kubernetes/cray-kafka-operator/values.yaml
@@ -10,7 +10,7 @@ strimzi-kafka-operator:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/quay.io/strimzi
     name: operator
-    tag: 0.27.0
+    tag: 0.27.1
     imagePullPolicy: IfNotPresent
 
   zookeeper:
@@ -18,67 +18,67 @@ strimzi-kafka-operator:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.27.0
+      tagPrefix: 0.27.1-noJSM-chainsaw
   kafka:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.27.0
+      tagPrefix: 0.27.1-noJSM-chainsaw
   kafkaConnect:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.27.0
+      tagPrefix: 0.27.1-noJSM-chainsaw
   kafkaConnects2i:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.27.0
+      tagPrefix: 0.27.1-noJSM-chainsaw
   topicOperator:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: operator
-      tag: 0.27.0
+      tag: 0.27.1
   userOperator:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: operator
-      tag: 0.27.0
+      tag: 0.27.1
   kafkaInit:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: operator
-      tag: 0.27.0
+      tag: 0.27.1
   tlsSidecarZookeeper:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.27.0
+      tagPrefix: 0.27.1-noJSM-chainsaw
   tlsSidecarKafka:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.27.0
+      tagPrefix: 0.27.1-noJSM-chainsaw
   tlsSidecarEntityOperator:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.27.0
+      tagPrefix: 0.27.1-noJSM-chainsaw
   kafkaMirrorMaker:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.27.0
+      tagPrefix: 0.27.1-noJSM-chainsaw
   kafkaBridge:
     image:
       registry: artifactory.algol60.net
@@ -90,7 +90,7 @@ strimzi-kafka-operator:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.27.0
+      tagPrefix: 0.27.1-noJSM-chainsaw
 
   # Increase resources.limits.cpu to 8 to reduce cpu throttling
   resources:


### PR DESCRIPTION
## Summary and Scope

Update the strimzi operator to 0.27.1. This is the last version that supports Kafka 2.X

## Issues and Related PRs

* Resolves [CASMPET-5362](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5362)

## Testing

Validated the operator worked and that kafka clusters came up properly.

### Tested on:

  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N/A
- Were continuous integration tests run? If not, why?  Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

