### PR TITLE
CASMPET-6936 Removing versions of kafka which are not used

### DIFF
--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.2.0
+version: 1.2.1
 description: An extension of the official kafka-operator helm chart
 name: cray-kafka-operator
 keywords:

--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -22,12 +22,6 @@ annotations:
       image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.41.0
     - name: kafka-bridge
       image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka-bridge:0.28.0
-    - name: kafka-3.6.0
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.6.0
-    - name: kafka-3.6.1
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.6.1
-    - name: kafka-3.6.2
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.6.2
     - name: kafka-3.7.0
       image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.7.0
   artifacthub.io/license: MIT


### PR DESCRIPTION
## Summary and Scope

There are multiple kafka versions associated with one strimzi operator version. Until now we are carrying the images of all these kafka versions. Removing all the other ones except for the latest one that is in use.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6936](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6936)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

