### PR TITLE
CASMPET-7382: Upgrade kafka-operator to version 0.45.0

### DIFF
--- a/kubernetes/cray-kafka-operator/Chart.yaml
+++ b/kubernetes/cray-kafka-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.2.1
+version: 1.3.0
 description: An extension of the official kafka-operator helm chart
 name: cray-kafka-operator
 keywords:
@@ -13,15 +13,15 @@ maintainers:
 dependencies:
   - name: strimzi-kafka-operator
     repository: https://strimzi.io/charts/
-    version: 0.41.0
+    version: 0.45.0
 icon: https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/main/documentation/logo/strimzi_logo.png
-appVersion: 0.41.0
+appVersion: 0.45.0
 annotations:
   artifacthub.io/images: |-
     - name: operator
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.41.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
     - name: kafka-bridge
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka-bridge:0.28.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka-bridge:0.31.1
     - name: kafka-3.7.0
-      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.7.0
+      image: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
   artifacthub.io/license: MIT

--- a/kubernetes/cray-kafka-operator/files/strimzi-crds-0.45.0.yaml
+++ b/kubernetes/cray-kafka-operator/files/strimzi-crds-0.45.0.yaml
@@ -103,7 +103,7 @@ spec:
                           description: "Type of the listener. The supported types are as follows: \n\n* `internal` type exposes Kafka internally only within the Kubernetes cluster.\n* `route` type uses OpenShift Routes to expose Kafka.\n* `loadbalancer` type uses LoadBalancer type services to expose Kafka.\n* `nodeport` type uses NodePort type services to expose Kafka.\n* `ingress` type uses Kubernetes Nginx Ingress to expose Kafka with TLS passthrough.\n* `cluster-ip` type uses a per-broker `ClusterIP` service.\n"
                         tls:
                           type: boolean
-                          description: Enables TLS encryption on the listener. This is a required property.
+                          description: "Enables TLS encryption on the listener. This is a required property. For `route` and `ingress` type listeners, TLS encryption must be always enabled."
                         authentication:
                           type: object
                           properties:
@@ -167,7 +167,7 @@ spec:
                               description: Enable or disable termination of Kafka broker processes due to potentially recoverable runtime errors during startup. Default value is `true`.
                             fallbackUserNameClaim:
                               type: string
-                              description: The fallback username claim to be used for the user id if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client id being provided in another claim. It only takes effect if `userNameClaim` is set.
+                              description: The fallback username claim to be used for the user ID if the claim specified by `userNameClaim` is not present. This is useful when `client_credentials` authentication only results in the client ID being provided in another claim. It only takes effect if `userNameClaim` is set.
                             fallbackUserNamePrefix:
                               type: string
                               description: "The prefix to use with the value of `fallbackUserNameClaim` to construct the user id. This only takes effect if `fallbackUserNameClaim` is true, and the value is present for the claim. Mapping usernames and client ids into the same user id space is useful in preventing name collisions."
@@ -210,7 +210,7 @@ spec:
                             listenerConfig:
                               x-kubernetes-preserve-unknown-fields: true
                               type: object
-                              description: Configuration to be used for a specific listener. All values are prefixed with listener.name._<listener_name>_.
+                              description: Configuration to be used for a specific listener. All values are prefixed with `listener.name.<listener_name>`.
                             maxSecondsWithoutReauthentication:
                               type: integer
                               description: "Maximum number of seconds the authenticated session remains valid without re-authentication. This enables Apache Kafka re-authentication feature, and causes sessions to expire when the access token expires. If the access token expires before max time or if max time is reached, the client has to re-authenticate, otherwise the server will drop the connection. Not set by default - the authenticated session does not expire when the access token expires. This option only applies to SASL_OAUTHBEARER authentication mechanism (when `enableOauthBearer` is `true`)."
@@ -234,7 +234,10 @@ spec:
                                 required:
                                 - key
                                 - secretName
-                              description: Secrets to be mounted to /opt/kafka/custom-authn-secrets/custom-listener-_<listener_name>-<port>_/_<secret_name>_.
+                              description: Secrets to be mounted to `/opt/kafka/custom-authn-secrets/custom-listener-<listener_name>-<port>/<secret_name>`.
+                            serverBearerTokenLocation:
+                              type: string
+                              description: Path to the file on the local filesystem that contains a bearer token to be used instead of client ID and secret when authenticating to authorization server.
                             tlsTrustedCertificates:
                               type: array
                               items:
@@ -245,10 +248,21 @@ spec:
                                     description: The name of the Secret containing the certificate.
                                   certificate:
                                     type: string
-                                    description: The name of the file certificate in the Secret.
+                                    description: The name of the file certificate in the secret.
+                                  pattern:
+                                    type: string
+                                    description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                                oneOf:
+                                - properties:
+                                    certificate: {}
+                                  required:
+                                  - certificate
+                                - properties:
+                                    pattern: {}
+                                  required:
+                                  - pattern
                                 required:
                                 - secretName
-                                - certificate
                               description: Trusted certificates for TLS connection to the OAuth server.
                             tokenEndpointUri:
                               type: string
@@ -267,6 +281,9 @@ spec:
                             userNameClaim:
                               type: string
                               description: "Name of the claim from the JWT authentication token, Introspection Endpoint response or User Info Endpoint response which will be used to extract the user id. Defaults to `sub`."
+                            userNamePrefix:
+                              type: string
+                              description: "The prefix to use with the value of `userNameClaim` to construct the user ID. This only takes effect if `userNameClaim` is specified and the value is present for the claim. When used in combination with `fallbackUserNameClaims`, it ensures consistent mapping of usernames and client IDs into the same user ID space and prevents name collisions."
                             validIssuerUri:
                               type: string
                               description: URI of the token issuer used for authentication.
@@ -282,34 +299,46 @@ spec:
                             brokerCertChainAndKey:
                               type: object
                               properties:
-                                key:
-                                  type: string
-                                  description: The name of the private key in the Secret.
                                 secretName:
                                   type: string
                                   description: The name of the Secret containing the certificate.
                                 certificate:
                                   type: string
                                   description: The name of the file certificate in the Secret.
+                                key:
+                                  type: string
+                                  description: The name of the private key in the Secret.
                               required:
-                              - key
                               - secretName
                               - certificate
+                              - key
                               description: Reference to the `Secret` which holds the certificate and private key pair which will be used for this listener. The certificate can optionally contain the whole chain. This field can be used only with listeners with enabled TLS encryption.
                             class:
                               type: string
-                              description: "Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller will be used. This field can only be used with `ingress` and `loadbalancer` type listeners. If not specified, the default controller is used. For an `ingress` listener, set the `ingressClassName` property in the `Ingress` resources. For a `loadbalancer` listener, set the `loadBalancerClass` property  in the `Service` resources."
+                              description: |-
+                                Configures a specific class for `Ingress` and `LoadBalancer` that defines which controller is used. If not specified, the default controller is used.
+
+                                * For an `ingress` listener, the operator uses this property to set the `ingressClassName` property in the `Ingress` resources.
+                                * For a `loadbalancer` listener, the operator uses this property to set the `loadBalancerClass` property  in the `Service` resources.
+
+                                For `ingress` and `loadbalancer` listeners only.
                             externalTrafficPolicy:
                               type: string
                               enum:
                               - Local
                               - Cluster
-                              description: "Specifies whether the service routes external traffic to node-local or cluster-wide endpoints. `Cluster` may cause a second hop to another node and obscures the client source IP. `Local` avoids a second hop for LoadBalancer and Nodeport type services and preserves the client source IP (when supported by the infrastructure). If unspecified, Kubernetes will use `Cluster` as the default.This field can be used only with `loadbalancer` or `nodeport` type listener."
+                              description: |-
+                                Specifies whether the service routes external traffic to cluster-wide or node-local endpoints:
+
+                                * `Cluster` may cause a second hop to another node and obscures the client source IP.
+                                * `Local` avoids a second hop for `LoadBalancer` and `Nodeport` type services and preserves the client source IP (when supported by the infrastructure).
+
+                                If unspecified, Kubernetes uses `Cluster` as the default. For `loadbalancer` or `nodeport` listeners only.
                             loadBalancerSourceRanges:
                               type: array
                               items:
                                 type: string
-                              description: "A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to load balancer type listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. This field can be used only with `loadbalancer` type listener."
+                              description: "A list of CIDR ranges (for example `10.0.0.0/8` or `130.211.204.1/32`) from which clients can connect to loadbalancer listeners. If supported by the platform, traffic through the loadbalancer is restricted to the specified CIDR ranges. This field is applicable only for loadbalancer type services and is ignored if the cloud provider does not support the feature. For `loadbalancer` listeners only."
                             bootstrap:
                               type: object
                               properties:
@@ -320,28 +349,28 @@ spec:
                                   description: Additional alternative names for the bootstrap service. The alternative names will be added to the list of subject alternative names of the TLS certificates.
                                 host:
                                   type: string
-                                  description: The bootstrap host. This field will be used in the Ingress resource or in the Route resource to specify the desired hostname. This field can be used only with `route` (optional) or `ingress` (required) type listeners.
+                                  description: Specifies the hostname used for the bootstrap resource. For `route` (optional) or `ingress` (required) listeners only. Ensure the hostname resolves to the Ingress endpoints; no validation is performed by Strimzi.
                                 nodePort:
                                   type: integer
-                                  description: Node port for the bootstrap service. This field can be used only with `nodeport` type listener.
+                                  description: Node port for the bootstrap service. For `nodeport` listeners only.
                                 loadBalancerIP:
                                   type: string
-                                  description: The loadbalancer is requested with the IP address specified in this field. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This field is ignored if the cloud provider does not support the feature.This field can be used only with `loadbalancer` type listener.
+                                  description: The loadbalancer is requested with the IP address specified in this property. This feature depends on whether the underlying cloud provider supports specifying the `loadBalancerIP` when a load balancer is created. This property is ignored if the cloud provider does not support the feature. For `loadbalancer` listeners only.
                                 annotations:
                                   additionalProperties:
                                     type: string
                                   type: object
-                                  description: "Annotations that will be added to the `Ingress`, `Route`, or `Service` resource. You can use this field to configure DNS providers such as External DNS. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners."
+                                  description: "Annotations added to `Ingress`, `Route`, or `Service` resources. You can use this property to configure DNS providers such as External DNS. For `loadbalancer`, `nodeport`, `route`, or `ingress` listeners only."
                                 labels:
                                   additionalProperties:
                                     type: string
                                   type: object
-                                  description: "Labels that will be added to the `Ingress`, `Route`, or `Service` resource. This field can be used only with `loadbalancer`, `nodeport`, `route`, or `ingress` type listeners."
+                                  description: "Labels added to `Ingress`, `Route`, or `Service` resources. For `loadbalancer`, `nodeport`, `route`, or `ingress` listeners only."
                                 externalIPs:
                                   type: array
                                   items:
                                     type: string
-                                  description: External IPs associated to the nodeport service. These IPs are used by clients external to the Kubernetes cluster to access the Kafka brokers. This field is helpful when `nodeport` without `externalIP` is not sufficient. For example on bare-metal Kubernetes clusters that do not support Loadbalancer service types. This field can only be used with `nodeport` type listener.
+                                  description: External IPs associated to the nodeport service. These IPs are used by clients external to the Kubernetes cluster to access the Kafka brokers. This property is helpful when `nodeport` without `externalIP` is not sufficient. For example on bare-metal Kubernetes clusters that do not support Loadbalancer service types. For `nodeport` listeners only.
                               description: Bootstrap configuration.
                             brokers:
                               type: array
@@ -390,7 +419,14 @@ spec:
                               - SingleStack
                               - PreferDualStack
                               - RequireDualStack
-                              description: "Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`. `SingleStack` is for a single IP family. `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters. `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters. If unspecified, Kubernetes will choose the default value based on the service type."
+                              description: |-
+                                Specifies the IP Family Policy used by the service. Available options are `SingleStack`, `PreferDualStack` and `RequireDualStack`:
+
+                                * `SingleStack` is for a single IP family.
+                                * `PreferDualStack` is for two IP families on dual-stack configured clusters or a single IP family on single-stack clusters.
+                                * `RequireDualStack` fails unless there are two IP families on dual-stack configured clusters.
+
+                                If unspecified, Kubernetes will choose the default value based on the service type.
                             ipFamilies:
                               type: array
                               items:
@@ -401,15 +437,21 @@ spec:
                               description: "Specifies the IP Families used by the service. Available options are `IPv4` and `IPv6`. If unspecified, Kubernetes will choose the default value based on the `ipFamilyPolicy` setting."
                             createBootstrapService:
                               type: boolean
-                              description: Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadBalancer` type listener.
+                              description: Whether to create the bootstrap service or not. The bootstrap service is created by default (if not specified differently). This field can be used with the `loadbalancer` listener.
                             finalizers:
                               type: array
                               items:
                                 type: string
-                              description: "A list of finalizers which will be configured for the `LoadBalancer` type Services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. This field can be used only with `loadbalancer` type listeners."
+                              description: "A list of finalizers configured for the `LoadBalancer` type services created for this listener. If supported by the platform, the finalizer `service.kubernetes.io/load-balancer-cleanup` to make sure that the external load balancer is deleted together with the service.For more information, see https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#garbage-collecting-load-balancers. For `loadbalancer` listeners only."
                             useServiceDnsDomain:
                               type: boolean
-                              description: "Configures whether the Kubernetes service DNS domain should be used or not. If set to `true`, the generated addresses will contain the service DNS domain suffix (by default `.cluster.local`, can be configured using environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`). Defaults to `false`.This field can be used only with `internal` and `cluster-ip` type listeners."
+                              description: |-
+                                Configures whether the Kubernetes service DNS domain should be included in the generated addresses.
+
+                                * If set to `false`, the generated addresses do not contain the service DNS domain suffix. For example, `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc`.
+                                * If set to `true`, the generated addresses contain the service DNS domain suffix. For example, `my-cluster-kafka-0.my-cluster-kafka-brokers.myproject.svc.cluster.local`.
+
+                                The default is `.cluster.local`, but this is customizable using the environment variable `KUBERNETES_SERVICE_DNS_DOMAIN`. For `internal` and `cluster-ip` listeners only.
                             maxConnections:
                               type: integer
                               description: The maximum number of connections we allow for this listener in the broker at any time. New connections are blocked if the limit is reached.
@@ -425,7 +467,7 @@ spec:
                               - InternalDNS
                               - Hostname
                               description: |-
-                                Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses will be used in the following order (the first one found will be used):
+                                Defines which address type should be used as the node address. Available types are: `ExternalDNS`, `ExternalIP`, `InternalDNS`, `InternalIP` and `Hostname`. By default, the addresses are used in the following order (the first one found is used):
 
                                 * `ExternalDNS`
                                 * `ExternalIP`
@@ -433,7 +475,22 @@ spec:
                                 * `InternalIP`
                                 * `Hostname`
 
-                                This field is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order. This field can only be used with `nodeport` type listener.
+                                This property is used to select the preferred address type, which is checked first. If no address is found for this address type, the other types are checked in the default order.For `nodeport` listeners only.
+                            publishNotReadyAddresses:
+                              type: boolean
+                              description: Configures whether the service endpoints are considered "ready" even if the Pods themselves are not. Defaults to `false`. This field can not be used with `internal` listeners.
+                            hostTemplate:
+                              type: string
+                              description: "Configures the template for generating the hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            advertisedHostTemplate:
+                              type: string
+                              description: "Configures the template for generating the advertised hostnames of the individual brokers. Valid placeholders that you can use in the template are `{nodeId}` and `{nodePodName}`."
+                            allocateLoadBalancerNodePorts:
+                              type: boolean
+                              description: |-
+                                Configures whether to allocate NodePort automatically for the `Service` with type `LoadBalancer`.
+                                This is a one to one with the `spec.allocateLoadBalancerNodePorts` configuration in the `Service` type
+                                For `loadbalancer` listeners only.
                           description: Additional listener configuration.
                         networkPolicyPeers:
                           type: array
@@ -495,11 +552,11 @@ spec:
                       - port
                       - type
                       - tls
-                    description: Configures listeners of Kafka brokers.
+                    description: Configures listeners to provide access to Kafka brokers.
                   config:
                     x-kubernetes-preserve-unknown-fields: true
                     type: object
-                    description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
+                    description: "Kafka broker config properties with the following prefixes cannot be set: listeners, advertised., broker., listener., host.name, port, inter.broker.listener.name, sasl., ssl., security., password., log.dir, zookeeper.connect, zookeeper.set.acl, zookeeper.ssl, zookeeper.clientCnxnSocket, authorizer., super.user, cruise.control.metrics.topic, cruise.control.metrics.reporter.bootstrap.servers, node.id, process.roles, controller., metadata.log.dir, zookeeper.metadata.migration.enable, client.quota.callback.static.kafka.admin., client.quota.callback.static.produce, client.quota.callback.static.fetch, client.quota.callback.static.storage.per.volume.limit.min.available., client.quota.callback.static.excluded.principal.name.list (with the exception of: zookeeper.connection.timeout.ms, sasl.server.max.receive.size, ssl.cipher.suites, ssl.protocol, ssl.enabled.protocols, ssl.secure.random.implementation, cruise.control.metrics.topic.num.partitions, cruise.control.metrics.topic.replication.factor, cruise.control.metrics.topic.retention.ms, cruise.control.metrics.topic.auto.create.retries, cruise.control.metrics.topic.auto.create.timeout.ms, cruise.control.metrics.topic.min.insync.replicas, controller.quorum.election.backoff.max.ms, controller.quorum.election.timeout.ms, controller.quorum.fetch.timeout.ms)."
                   storage:
                     type: object
                     properties:
@@ -529,7 +586,7 @@ spec:
                             broker:
                               type: integer
                               description: Id of the kafka broker (broker identifier).
-                        description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                        description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                       selector:
                         additionalProperties:
                           type: string
@@ -580,7 +637,7 @@ spec:
                                   broker:
                                     type: integer
                                     description: Id of the kafka broker (broker identifier).
-                              description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                              description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                             selector:
                               additionalProperties:
                                 type: string
@@ -687,10 +744,21 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
+                            pattern:
+                              type: string
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
@@ -957,6 +1025,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -1425,7 +1500,105 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                          volumes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  description: Name to use for the volume. Required.
+                                secret:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  description: Secret to use populate the volume.
+                                configMap:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: ConfigMap to use to populate the volume.
+                                emptyDir:
+                                  type: object
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      type: object
+                                      properties:
+                                        amount:
+                                          type: string
+                                        format:
+                                          type: string
+                                  description: EmptyDir to use to populate the volume.
+                                persistentVolumeClaim:
+                                  type: object
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                csi:
+                                  type: object
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  description: CSIVolumeSource object to use to populate the volume.
+                              oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  emptyDir: {}
+                                  persistentVolumeClaim: {}
+                                  csi: {}
+                            description: Additional volumes that can be mounted to the pod.
                         description: Template for Kafka `Pods`.
                       bootstrapService:
                         type: object
@@ -1655,12 +1828,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -1714,6 +1936,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for the Kafka broker container.
                       initContainer:
                         type: object
@@ -1729,12 +1971,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -1788,6 +2079,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for the Kafka init container.
                       clusterCaCert:
                         type: object
@@ -1906,6 +2217,48 @@ spec:
                     required:
                     - type
                     description: Configure the tiered storage feature for Kafka brokers.
+                  quotas:
+                    type: object
+                    properties:
+                      consumerByteRate:
+                        type: integer
+                        minimum: 0
+                        description: "A per-broker byte-rate quota for clients consuming from a broker, independent of their number. If clients consume at maximum speed, the quota is shared equally between all non-excluded consumers. Otherwise, the quota is divided based on each client's consumption rate."
+                      controllerMutationRate:
+                        type: number
+                        minimum: 0
+                        description: "The default client quota on the rate at which mutations are accepted per second for create topic requests, create partition requests, and delete topic requests, defined for each broker. The mutations rate is measured by the number of partitions created or deleted. Applied on a per-broker basis."
+                      excludedPrincipals:
+                        type: array
+                        items:
+                          type: string
+                        description: "List of principals that are excluded from the quota. The principals have to be prefixed with `User:`, for example `User:my-user;User:CN=my-other-user`."
+                      minAvailableBytesPerVolume:
+                        type: integer
+                        minimum: 0
+                        description: Stop message production if the available size (in bytes) of the storage is lower than or equal to this specified value. This condition is mutually exclusive with `minAvailableRatioPerVolume`.
+                      minAvailableRatioPerVolume:
+                        type: number
+                        minimum: 0
+                        maximum: 1
+                        description: Stop message production if the percentage of available storage space falls below or equals the specified ratio (set as a decimal representing a percentage). This condition is mutually exclusive with `minAvailableBytesPerVolume`.
+                      producerByteRate:
+                        type: integer
+                        minimum: 0
+                        description: "A per-broker byte-rate quota for clients producing to a broker, independent of their number. If clients produce at maximum speed, the quota is shared equally between all non-excluded producers. Otherwise, the quota is divided based on each client's production rate."
+                      requestPercentage:
+                        type: integer
+                        minimum: 0
+                        description: The default client quota limits the maximum CPU utilization of each client as a percentage of the network and I/O threads of each broker. Applied on a per-broker basis.
+                      type:
+                        type: string
+                        enum:
+                        - kafka
+                        - strimzi
+                        description: "Quotas plugin type. Currently, the supported types are `kafka` and `strimzi`. `kafka` quotas type uses Kafka's built-in quotas plugin. `strimzi` quotas type uses Strimzi quotas plugin."
+                    required:
+                    - type
+                    description: "Quotas plugin configuration for Kafka brokers allows setting quotas for disk usage, produce/fetch rates, and more. Supported plugin types include `kafka` (default) and `strimzi`. If not specified, the default `kafka` quotas plugin is used."
                 required:
                 - listeners
                 description: Configuration of the Kafka cluster.
@@ -1948,7 +2301,7 @@ spec:
                             broker:
                               type: integer
                               description: Id of the kafka broker (broker identifier).
-                        description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                        description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                       selector:
                         additionalProperties:
                           type: string
@@ -2226,6 +2579,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -2694,7 +3054,105 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                          volumes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  description: Name to use for the volume. Required.
+                                secret:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  description: Secret to use populate the volume.
+                                configMap:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: ConfigMap to use to populate the volume.
+                                emptyDir:
+                                  type: object
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      type: object
+                                      properties:
+                                        amount:
+                                          type: string
+                                        format:
+                                          type: string
+                                  description: EmptyDir to use to populate the volume.
+                                persistentVolumeClaim:
+                                  type: object
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                csi:
+                                  type: object
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  description: CSIVolumeSource object to use to populate the volume.
+                              oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  emptyDir: {}
+                                  persistentVolumeClaim: {}
+                                  csi: {}
+                            description: Additional volumes that can be mounted to the pod.
                         description: Template for ZooKeeper `Pods`.
                       clientService:
                         type: object
@@ -2816,12 +3274,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -2875,6 +3382,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for the ZooKeeper container.
                       serviceAccount:
                         type: object
@@ -2932,7 +3459,11 @@ spec:
                       reconciliationIntervalSeconds:
                         type: integer
                         minimum: 0
-                        description: Interval between periodic reconciliations.
+                        description: Interval between periodic reconciliations in seconds. Ignored if reconciliationIntervalMs is set.
+                      reconciliationIntervalMs:
+                        type: integer
+                        minimum: 0
+                        description: Interval between periodic reconciliations in milliseconds.
                       zookeeperSessionTimeoutSeconds:
                         type: integer
                         minimum: 0
@@ -3116,7 +3647,11 @@ spec:
                       reconciliationIntervalSeconds:
                         type: integer
                         minimum: 0
-                        description: Interval between periodic reconciliations.
+                        description: Interval between periodic reconciliations in seconds. Ignored if reconciliationIntervalMs is set.
+                      reconciliationIntervalMs:
+                        type: integer
+                        minimum: 0
+                        description: Interval between periodic reconciliations in milliseconds.
                       zookeeperSessionTimeoutSeconds:
                         type: integer
                         minimum: 0
@@ -3412,6 +3947,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -3880,7 +4422,105 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                          volumes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  description: Name to use for the volume. Required.
+                                secret:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  description: Secret to use populate the volume.
+                                configMap:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: ConfigMap to use to populate the volume.
+                                emptyDir:
+                                  type: object
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      type: object
+                                      properties:
+                                        amount:
+                                          type: string
+                                        format:
+                                          type: string
+                                  description: EmptyDir to use to populate the volume.
+                                persistentVolumeClaim:
+                                  type: object
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                csi:
+                                  type: object
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  description: CSIVolumeSource object to use to populate the volume.
+                              oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  emptyDir: {}
+                                  persistentVolumeClaim: {}
+                                  csi: {}
+                            description: Additional volumes that can be mounted to the pod.
                         description: Template for Entity Operator `Pods`.
                       topicOperatorContainer:
                         type: object
@@ -3896,12 +4536,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -3955,6 +4644,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for the Entity Topic Operator container.
                       userOperatorContainer:
                         type: object
@@ -3970,12 +4679,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -4029,6 +4787,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for the Entity User Operator container.
                       tlsSidecarContainer:
                         type: object
@@ -4044,12 +4822,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -4103,6 +4930,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for the Entity Operator TLS sidecar container.
                       serviceAccount:
                         type: object
@@ -4519,6 +5366,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -4987,7 +5841,105 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                          volumes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  description: Name to use for the volume. Required.
+                                secret:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  description: Secret to use populate the volume.
+                                configMap:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: ConfigMap to use to populate the volume.
+                                emptyDir:
+                                  type: object
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      type: object
+                                      properties:
+                                        amount:
+                                          type: string
+                                        format:
+                                          type: string
+                                  description: EmptyDir to use to populate the volume.
+                                persistentVolumeClaim:
+                                  type: object
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                csi:
+                                  type: object
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  description: CSIVolumeSource object to use to populate the volume.
+                              oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  emptyDir: {}
+                                  persistentVolumeClaim: {}
+                                  csi: {}
+                            description: Additional volumes that can be mounted to the pod.
                         description: Template for Cruise Control `Pods`.
                       apiService:
                         type: object
@@ -5058,12 +6010,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -5117,6 +6118,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for the Cruise Control container.
                       tlsSidecarContainer:
                         type: object
@@ -5132,12 +6153,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -5191,6 +6261,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for the Cruise Control TLS sidecar container.
                       serviceAccount:
                         type: object
@@ -5291,6 +6381,53 @@ spec:
                     - type
                     - valueFrom
                     description: Metrics configuration.
+                  apiUsers:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        enum:
+                        - hashLoginService
+                        description: "Type of the Cruise Control API users configuration. Supported format is: `hashLoginService`."
+                      valueFrom:
+                        type: object
+                        properties:
+                          secretKeyRef:
+                            type: object
+                            properties:
+                              key:
+                                type: string
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            description: Selects a key of a Secret in the resource's namespace.
+                        description: Secret from which the custom Cruise Control API authentication credentials are read.
+                    required:
+                    - type
+                    - valueFrom
+                    description: Configuration of the Cruise Control REST API users.
+                  autoRebalance:
+                    type: array
+                    minItems: 1
+                    items:
+                      type: object
+                      properties:
+                        mode:
+                          type: string
+                          enum:
+                          - add-brokers
+                          - remove-brokers
+                          description: "Specifies the mode for automatically rebalancing when brokers are added or removed. Supported modes are `add-brokers` and `remove-brokers`. \n"
+                        template:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                          description: Reference to the KafkaRebalance custom resource to be used as the configuration template for the auto-rebalancing on scaling when running for the corresponding mode.
+                      required:
+                      - mode
+                    description: "Auto-rebalancing on scaling related configuration listing the modes, when brokers are added or removed, with the corresponding rebalance template configurations.If this field is set, at least one mode has to be defined."
                 description: Configuration for Cruise Control deployment. Deploys a Cruise Control instance when specified.
               jmxTrans:
                 type: object
@@ -5435,6 +6572,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -5903,7 +7047,105 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                          volumes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  description: Name to use for the volume. Required.
+                                secret:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  description: Secret to use populate the volume.
+                                configMap:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: ConfigMap to use to populate the volume.
+                                emptyDir:
+                                  type: object
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      type: object
+                                      properties:
+                                        amount:
+                                          type: string
+                                        format:
+                                          type: string
+                                  description: EmptyDir to use to populate the volume.
+                                persistentVolumeClaim:
+                                  type: object
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                csi:
+                                  type: object
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  description: CSIVolumeSource object to use to populate the volume.
+                              oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  emptyDir: {}
+                                  persistentVolumeClaim: {}
+                                  csi: {}
+                            description: Additional volumes that can be mounted to the pod.
                         description: Template for JmxTrans `Pods`.
                       container:
                         type: object
@@ -5919,12 +7161,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -5978,6 +7269,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for JmxTrans container.
                       serviceAccount:
                         type: object
@@ -6159,6 +7470,13 @@ spec:
                           securityContext:
                             type: object
                             properties:
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               fsGroup:
                                 type: integer
                               fsGroupChangePolicy:
@@ -6627,7 +7945,105 @@ spec:
                           tmpDirSizeLimit:
                             type: string
                             pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                            description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                            description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                          volumes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                  description: Name to use for the volume. Required.
+                                secret:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  description: Secret to use populate the volume.
+                                configMap:
+                                  type: object
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: ConfigMap to use to populate the volume.
+                                emptyDir:
+                                  type: object
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      type: object
+                                      properties:
+                                        amount:
+                                          type: string
+                                        format:
+                                          type: string
+                                  description: EmptyDir to use to populate the volume.
+                                persistentVolumeClaim:
+                                  type: object
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  description: PersistentVolumeClaim object to use to populate the volume.
+                                csi:
+                                  type: object
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  description: CSIVolumeSource object to use to populate the volume.
+                              oneOf:
+                              - properties:
+                                  secret: {}
+                                  configMap: {}
+                                  emptyDir: {}
+                                  persistentVolumeClaim: {}
+                                  csi: {}
+                            description: Additional volumes that can be mounted to the pod.
                         description: Template for Kafka Exporter `Pods`.
                       service:
                         type: object
@@ -6661,12 +8077,61 @@ spec:
                                 value:
                                   type: string
                                   description: The environment variable value.
+                                valueFrom:
+                                  type: object
+                                  properties:
+                                    secretKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a secret.
+                                    configMapKeyRef:
+                                      type: object
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      description: Reference to a key in a config map.
+                                  oneOf:
+                                  - properties:
+                                      secretKeyRef: {}
+                                    required:
+                                    - secretKeyRef
+                                  - properties:
+                                      configMapKeyRef: {}
+                                    required:
+                                    - configMapKeyRef
+                                  description: Reference to the secret or config map property to which the environment variable is set.
+                              oneOf:
+                              - properties:
+                                  value: {}
+                                required:
+                                - value
+                              - properties:
+                                  valueFrom: {}
+                                required:
+                                - valueFrom
                             description: Environment variables which should be applied to the container.
                           securityContext:
                             type: object
                             properties:
                               allowPrivilegeEscalation:
                                 type: boolean
+                              appArmorProfile:
+                                type: object
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
                               capabilities:
                                 type: object
                                 properties:
@@ -6720,6 +8185,26 @@ spec:
                                   runAsUserName:
                                     type: string
                             description: Security context for the container.
+                          volumeMounts:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                recursiveReadOnly:
+                                  type: string
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                            description: Additional volume mounts which should be applied to the container.
                         description: Template for the Kafka Exporter container.
                       serviceAccount:
                         type: object
@@ -6817,6 +8302,11 @@ spec:
                       type: string
                       description: The name of the KafkaNodePool used by this Kafka resource.
                 description: List of the KafkaNodePools used by this Kafka cluster.
+              registeredNodeIds:
+                type: array
+                items:
+                  type: integer
+                description: Registered node IDs used by this Kafka cluster. This field is used for internal purposes only and will be removed in the future.
               clusterId:
                 type: string
                 description: Kafka cluster Id.
@@ -6839,6 +8329,37 @@ spec:
                 - PreKRaft
                 - KRaft
                 description: "Defines where cluster metadata are stored. Possible values are: ZooKeeper if the metadata are stored in ZooKeeper; KRaftMigration if the controllers are connected to ZooKeeper, brokers are being rolled with Zookeeper migration enabled and connection information to controllers, and the metadata migration process is running; KRaftDualWriting if the metadata migration process finished and the cluster is in dual-write mode; KRaftPostMigration if the brokers are fully KRaft-based but controllers being rolled to disconnect from ZooKeeper; PreKRaft if brokers and controller are fully KRaft-based, metadata are stored in KRaft, but ZooKeeper must be deleted; KRaft if the metadata are stored in KRaft."
+              autoRebalance:
+                type: object
+                properties:
+                  state:
+                    type: string
+                    enum:
+                    - Idle
+                    - RebalanceOnScaleDown
+                    - RebalanceOnScaleUp
+                    description: "The current state of an auto-rebalancing operation. Possible values are: \n\n* `Idle` as the initial state when an auto-rebalancing is requested or as final state when it completes or fails.\n* `RebalanceOnScaleDown` if an auto-rebalance related to a scale-down operation is running.\n* `RebalanceOnScaleUp` if an auto-rebalance related to a scale-up operation is running."
+                  lastTransitionTime:
+                    type: string
+                    description: The timestamp of the latest auto-rebalancing state update.
+                  modes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        mode:
+                          type: string
+                          enum:
+                          - add-brokers
+                          - remove-brokers
+                          description: "Mode for which there is an auto-rebalancing operation in progress or queued, when brokers are added or removed. The possible modes are `add-brokers` and `remove-brokers`."
+                        brokers:
+                          type: array
+                          items:
+                            type: integer
+                          description: "List of broker IDs involved in an auto-rebalancing operation related to the current mode. \nThe list contains one of the following: \n\n* Broker IDs for a current auto-rebalance. \n* Broker IDs for a queued auto-rebalance (if a previous auto-rebalance is still in progress). \n"
+                    description: "List of modes where an auto-rebalancing operation is either running or queued. \nEach mode entry (`add-brokers` or `remove-brokers`) includes one of the following: \n\n* Broker IDs for a current auto-rebalance. \n* Broker IDs for a queued auto-rebalance (if a previous rebalance is still in progress)."
+                description: The status of an auto-rebalancing triggered by a cluster scaling request.
             description: "The status of the Kafka and ZooKeeper clusters, and Topic Operator."
 
 ---
@@ -6922,10 +8443,21 @@ spec:
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
-                          description: The name of the file certificate in the Secret.
+                          description: The name of the file certificate in the secret.
+                        pattern:
+                          type: string
+                          description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                      oneOf:
+                      - properties:
+                          certificate: {}
+                        required:
+                        - certificate
+                      - properties:
+                          pattern: {}
+                        required:
+                        - pattern
                       required:
                       - secretName
-                      - certificate
                     description: Trusted certificates for TLS connection.
                 description: TLS configuration.
               authentication:
@@ -6947,26 +8479,48 @@ spec:
                   accessTokenIsJwt:
                     type: boolean
                     description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                  accessTokenLocation:
+                    type: string
+                    description: Path to the token file containing an access token to be used for authentication.
                   audience:
                     type: string
                     description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
                   certificateAndKey:
                     type: object
                     properties:
-                      key:
-                        type: string
-                        description: The name of the private key in the Secret.
                       secretName:
                         type: string
                         description: The name of the Secret containing the certificate.
                       certificate:
                         type: string
                         description: The name of the file certificate in the Secret.
+                      key:
+                        type: string
+                        description: The name of the private key in the Secret.
+                    required:
+                    - secretName
+                    - certificate
+                    - key
+                    description: Reference to the `Secret` which holds the certificate and private key pair.
+                  clientAssertion:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: The key under which the secret value is stored in the Kubernetes Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Kubernetes Secret containing the secret value.
                     required:
                     - key
                     - secretName
-                    - certificate
-                    description: Reference to the `Secret` which holds the certificate and private key pair.
+                    description: Link to Kubernetes secret containing the client assertion which was manually configured for the client.
+                  clientAssertionLocation:
+                    type: string
+                    description: Path to the file containing the client assertion to be used for authentication.
+                  clientAssertionType:
+                    type: string
+                    description: "The client assertion type. If not set, and either `clientAssertion` or `clientAssertionLocation` is configured, this value defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`."
                   clientId:
                     type: string
                     description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
@@ -7033,6 +8587,11 @@ spec:
                     - key
                     - secretName
                     description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                  saslExtensions:
+                    additionalProperties:
+                      type: string
+                    type: object
+                    description: SASL extensions parameters.
                   scope:
                     type: string
                     description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
@@ -7046,10 +8605,21 @@ spec:
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
-                          description: The name of the file certificate in the Secret.
+                          description: The name of the file certificate in the secret.
+                        pattern:
+                          type: string
+                          description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                      oneOf:
+                      - properties:
+                          certificate: {}
+                        required:
+                        - certificate
+                      - properties:
+                          pattern: {}
+                        required:
+                        - pattern
                       required:
                       - secretName
-                      - certificate
                     description: Trusted certificates for TLS connection to the OAuth server.
                   tokenEndpointUri:
                     type: string
@@ -7350,6 +8920,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -7818,7 +9395,105 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                      volumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: Secret to use populate the volume.
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: ConfigMap to use to populate the volume.
+                            emptyDir:
+                              type: object
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  type: object
+                                  properties:
+                                    amount:
+                                      type: string
+                                    format:
+                                      type: string
+                              description: EmptyDir to use to populate the volume.
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: PersistentVolumeClaim object to use to populate the volume.
+                            csi:
+                              type: object
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              description: CSIVolumeSource object to use to populate the volume.
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              emptyDir: {}
+                              persistentVolumeClaim: {}
+                              csi: {}
+                        description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect `Pods`.
                   apiService:
                     type: object
@@ -7900,12 +9575,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -7959,6 +9683,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka Connect container.
                   initContainer:
                     type: object
@@ -7974,12 +9718,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -8033,6 +9826,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka init container.
                   podDisruptionBudget:
                     type: object
@@ -8120,6 +9933,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -8588,7 +10408,105 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                      volumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: Secret to use populate the volume.
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: ConfigMap to use to populate the volume.
+                            emptyDir:
+                              type: object
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  type: object
+                                  properties:
+                                    amount:
+                                      type: string
+                                    format:
+                                      type: string
+                              description: EmptyDir to use to populate the volume.
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: PersistentVolumeClaim object to use to populate the volume.
+                            csi:
+                              type: object
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              description: CSIVolumeSource object to use to populate the volume.
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              emptyDir: {}
+                              persistentVolumeClaim: {}
+                              csi: {}
+                        description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                   buildContainer:
                     type: object
@@ -8604,12 +10522,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -8663,6 +10630,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
                   buildConfig:
                     type: object
@@ -8721,7 +10708,7 @@ spec:
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
+                description: "Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
               externalConfiguration:
                 type: object
                 properties:
@@ -8756,6 +10743,15 @@ spec:
                                 optional:
                                   type: boolean
                               description: Reference to a key in a ConfigMap.
+                          oneOf:
+                          - properties:
+                              secretKeyRef: {}
+                            required:
+                            - secretKeyRef
+                          - properties:
+                              configMapKeyRef: {}
+                            required:
+                            - configMapKeyRef
                           description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                       required:
                       - name
@@ -8811,6 +10807,15 @@ spec:
                             optional:
                               type: boolean
                           description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
+                      oneOf:
+                      - properties:
+                          secret: {}
+                        required:
+                        - secret
+                      - properties:
+                          configMap: {}
+                        required:
+                        - configMap
                       required:
                       - name
                     description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
@@ -8825,7 +10830,7 @@ spec:
                         type: array
                         items:
                           type: string
-                        description: "Configures additional options which will be passed to the Kaniko executor when building the new Connect image. Allowed options are: --customPlatform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run. These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image."
+                        description: "Configures additional options which will be passed to the Kaniko executor when building the new Connect image. Allowed options are: --customPlatform, --custom-platform, --insecure, --insecure-pull, --insecure-registry, --log-format, --log-timestamp, --registry-mirror, --reproducible, --single-snapshot, --skip-tls-verify, --skip-tls-verify-pull, --skip-tls-verify-registry, --verbosity, --snapshotMode, --use-new-run, --registry-certificate, --registry-client-cert. These options will be used only on Kubernetes where the Kaniko executor is used. They will be ignored on OpenShift. The options are described in the link:https://github.com/GoogleContainerTools/kaniko[Kaniko GitHub repository^]. Changing this field does not trigger new build of the Kafka Connect image."
                       image:
                         type: string
                         description: The name of the image which will be built. Required.
@@ -9622,7 +11627,7 @@ spec:
                             - DescribeConfigs
                             - IdempotentWrite
                             - All
-                          description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                          description: "List of operations to allow or deny. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All. Only certain operations work with the specified resource."
                       required:
                       - resource
                     description: List of ACL rules which should be applied to this user.
@@ -9853,7 +11858,7 @@ spec:
                             - DescribeConfigs
                             - IdempotentWrite
                             - All
-                          description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                          description: "List of operations to allow or deny. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All. Only certain operations work with the specified resource."
                       required:
                       - resource
                     description: List of ACL rules which should be applied to this user.
@@ -10084,7 +12089,7 @@ spec:
                             - DescribeConfigs
                             - IdempotentWrite
                             - All
-                          description: "List of operations which will be allowed or denied. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All."
+                          description: "List of operations to allow or deny. Supported operations are: Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs, DescribeConfigs, IdempotentWrite and All. Only certain operations work with the specified resource."
                       required:
                       - resource
                     description: List of ACL rules which should be applied to this user.
@@ -10286,26 +12291,48 @@ spec:
                       accessTokenIsJwt:
                         type: boolean
                         description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                      accessTokenLocation:
+                        type: string
+                        description: Path to the token file containing an access token to be used for authentication.
                       audience:
                         type: string
                         description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
                       certificateAndKey:
                         type: object
                         properties:
-                          key:
-                            type: string
-                            description: The name of the private key in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
                           certificate:
                             type: string
                             description: The name of the file certificate in the Secret.
+                          key:
+                            type: string
+                            description: The name of the private key in the Secret.
+                        required:
+                        - secretName
+                        - certificate
+                        - key
+                        description: Reference to the `Secret` which holds the certificate and private key pair.
+                      clientAssertion:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing the secret value.
                         required:
                         - key
                         - secretName
-                        - certificate
-                        description: Reference to the `Secret` which holds the certificate and private key pair.
+                        description: Link to Kubernetes secret containing the client assertion which was manually configured for the client.
+                      clientAssertionLocation:
+                        type: string
+                        description: Path to the file containing the client assertion to be used for authentication.
+                      clientAssertionType:
+                        type: string
+                        description: "The client assertion type. If not set, and either `clientAssertion` or `clientAssertionLocation` is configured, this value defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`."
                       clientId:
                         type: string
                         description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
@@ -10372,6 +12399,11 @@ spec:
                         - key
                         - secretName
                         description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                      saslExtensions:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        description: SASL extensions parameters.
                       scope:
                         type: string
                         description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
@@ -10385,10 +12417,21 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
+                            pattern:
+                              type: string
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
@@ -10421,10 +12464,21 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
+                            pattern:
+                              type: string
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection.
                     description: TLS configuration for connecting MirrorMaker to the cluster.
                   config:
@@ -10463,26 +12517,48 @@ spec:
                       accessTokenIsJwt:
                         type: boolean
                         description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                      accessTokenLocation:
+                        type: string
+                        description: Path to the token file containing an access token to be used for authentication.
                       audience:
                         type: string
                         description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
                       certificateAndKey:
                         type: object
                         properties:
-                          key:
-                            type: string
-                            description: The name of the private key in the Secret.
                           secretName:
                             type: string
                             description: The name of the Secret containing the certificate.
                           certificate:
                             type: string
                             description: The name of the file certificate in the Secret.
+                          key:
+                            type: string
+                            description: The name of the private key in the Secret.
+                        required:
+                        - secretName
+                        - certificate
+                        - key
+                        description: Reference to the `Secret` which holds the certificate and private key pair.
+                      clientAssertion:
+                        type: object
+                        properties:
+                          key:
+                            type: string
+                            description: The key under which the secret value is stored in the Kubernetes Secret.
+                          secretName:
+                            type: string
+                            description: The name of the Kubernetes Secret containing the secret value.
                         required:
                         - key
                         - secretName
-                        - certificate
-                        description: Reference to the `Secret` which holds the certificate and private key pair.
+                        description: Link to Kubernetes secret containing the client assertion which was manually configured for the client.
+                      clientAssertionLocation:
+                        type: string
+                        description: Path to the file containing the client assertion to be used for authentication.
+                      clientAssertionType:
+                        type: string
+                        description: "The client assertion type. If not set, and either `clientAssertion` or `clientAssertionLocation` is configured, this value defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`."
                       clientId:
                         type: string
                         description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
@@ -10549,6 +12625,11 @@ spec:
                         - key
                         - secretName
                         description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                      saslExtensions:
+                        additionalProperties:
+                          type: string
+                        type: object
+                        description: SASL extensions parameters.
                       scope:
                         type: string
                         description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
@@ -10562,10 +12643,21 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
+                            pattern:
+                              type: string
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection to the OAuth server.
                       tokenEndpointUri:
                         type: string
@@ -10602,10 +12694,21 @@ spec:
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
-                              description: The name of the file certificate in the Secret.
+                              description: The name of the file certificate in the secret.
+                            pattern:
+                              type: string
+                              description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                          oneOf:
+                          - properties:
+                              certificate: {}
+                            required:
+                            - certificate
+                          - properties:
+                              pattern: {}
+                            required:
+                            - pattern
                           required:
                           - secretName
-                          - certificate
                         description: Trusted certificates for TLS connection.
                     description: TLS configuration for connecting MirrorMaker to the cluster.
                 required:
@@ -10800,6 +12903,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -11268,7 +13378,105 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                      volumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: Secret to use populate the volume.
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: ConfigMap to use to populate the volume.
+                            emptyDir:
+                              type: object
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  type: object
+                                  properties:
+                                    amount:
+                                      type: string
+                                    format:
+                                      type: string
+                              description: EmptyDir to use to populate the volume.
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: PersistentVolumeClaim object to use to populate the volume.
+                            csi:
+                              type: object
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              description: CSIVolumeSource object to use to populate the volume.
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              emptyDir: {}
+                              persistentVolumeClaim: {}
+                              csi: {}
+                        description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka MirrorMaker `Pods`.
                   podDisruptionBudget:
                     type: object
@@ -11306,12 +13514,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -11365,6 +13622,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for Kafka MirrorMaker container.
                   serviceAccount:
                     type: object
@@ -11566,10 +13843,21 @@ spec:
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
-                          description: The name of the file certificate in the Secret.
+                          description: The name of the file certificate in the secret.
+                        pattern:
+                          type: string
+                          description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                      oneOf:
+                      - properties:
+                          certificate: {}
+                        required:
+                        - certificate
+                      - properties:
+                          pattern: {}
+                        required:
+                        - pattern
                       required:
                       - secretName
-                      - certificate
                     description: Trusted certificates for TLS connection.
                 description: TLS configuration for connecting Kafka Bridge to the cluster.
               authentication:
@@ -11591,26 +13879,48 @@ spec:
                   accessTokenIsJwt:
                     type: boolean
                     description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                  accessTokenLocation:
+                    type: string
+                    description: Path to the token file containing an access token to be used for authentication.
                   audience:
                     type: string
                     description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
                   certificateAndKey:
                     type: object
                     properties:
-                      key:
-                        type: string
-                        description: The name of the private key in the Secret.
                       secretName:
                         type: string
                         description: The name of the Secret containing the certificate.
                       certificate:
                         type: string
                         description: The name of the file certificate in the Secret.
+                      key:
+                        type: string
+                        description: The name of the private key in the Secret.
+                    required:
+                    - secretName
+                    - certificate
+                    - key
+                    description: Reference to the `Secret` which holds the certificate and private key pair.
+                  clientAssertion:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: The key under which the secret value is stored in the Kubernetes Secret.
+                      secretName:
+                        type: string
+                        description: The name of the Kubernetes Secret containing the secret value.
                     required:
                     - key
                     - secretName
-                    - certificate
-                    description: Reference to the `Secret` which holds the certificate and private key pair.
+                    description: Link to Kubernetes secret containing the client assertion which was manually configured for the client.
+                  clientAssertionLocation:
+                    type: string
+                    description: Path to the file containing the client assertion to be used for authentication.
+                  clientAssertionType:
+                    type: string
+                    description: "The client assertion type. If not set, and either `clientAssertion` or `clientAssertionLocation` is configured, this value defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`."
                   clientId:
                     type: string
                     description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
@@ -11677,6 +13987,11 @@ spec:
                     - key
                     - secretName
                     description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                  saslExtensions:
+                    additionalProperties:
+                      type: string
+                    type: object
+                    description: SASL extensions parameters.
                   scope:
                     type: string
                     description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
@@ -11690,10 +14005,21 @@ spec:
                           description: The name of the Secret containing the certificate.
                         certificate:
                           type: string
-                          description: The name of the file certificate in the Secret.
+                          description: The name of the file certificate in the secret.
+                        pattern:
+                          type: string
+                          description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                      oneOf:
+                      - properties:
+                          certificate: {}
+                        required:
+                        - certificate
+                      - properties:
+                          pattern: {}
+                        required:
+                        - pattern
                       required:
                       - secretName
-                      - certificate
                     description: Trusted certificates for TLS connection to the OAuth server.
                   tokenEndpointUri:
                     type: string
@@ -11749,6 +14075,12 @@ spec:
               consumer:
                 type: object
                 properties:
+                  enabled:
+                    type: boolean
+                    description: Whether the HTTP consumer should be enabled or disabled. The default is enabled (`true`).
+                  timeoutSeconds:
+                    type: integer
+                    description: "The timeout in seconds for deleting inactive consumers, default is -1 (disabled)."
                   config:
                     x-kubernetes-preserve-unknown-fields: true
                     type: object
@@ -11757,6 +14089,9 @@ spec:
               producer:
                 type: object
                 properties:
+                  enabled:
+                    type: boolean
+                    description: Whether the HTTP producer should be enabled or disabled. The default is enabled (`true`).
                   config:
                     x-kubernetes-preserve-unknown-fields: true
                     type: object
@@ -11971,6 +14306,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -12439,7 +14781,105 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                      volumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: Secret to use populate the volume.
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: ConfigMap to use to populate the volume.
+                            emptyDir:
+                              type: object
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  type: object
+                                  properties:
+                                    amount:
+                                      type: string
+                                    format:
+                                      type: string
+                              description: EmptyDir to use to populate the volume.
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: PersistentVolumeClaim object to use to populate the volume.
+                            csi:
+                              type: object
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              description: CSIVolumeSource object to use to populate the volume.
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              emptyDir: {}
+                              persistentVolumeClaim: {}
+                              csi: {}
+                        description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Bridge `Pods`.
                   apiService:
                     type: object
@@ -12510,12 +14950,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -12569,6 +15058,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka Bridge container.
                   clusterRoleBinding:
                     type: object
@@ -12620,12 +15129,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -12679,6 +15237,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka Bridge init container.
                 description: Template for Kafka Bridge resources. The template allows users to specify how a `Deployment` and `Pod` is generated.
               tracing:
@@ -12817,7 +15395,7 @@ spec:
               config:
                 x-kubernetes-preserve-unknown-fields: true
                 type: object
-                description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
               pause:
                 type: boolean
                 description: Whether the connector should be paused. Defaults to false.
@@ -12828,6 +15406,30 @@ spec:
                 - stopped
                 - running
                 description: The state the connector should be in. Defaults to running.
+              listOffsets:
+                type: object
+                properties:
+                  toConfigMap:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                    description: Reference to the ConfigMap where the list of offsets will be written to.
+                required:
+                - toConfigMap
+                description: Configuration for listing offsets.
+              alterOffsets:
+                type: object
+                properties:
+                  fromConfigMap:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                    description: Reference to the ConfigMap where the new offsets are stored.
+                required:
+                - fromConfigMap
+                description: Configuration for altering offsets.
             description: The specification of the Kafka Connector.
           status:
             type: object
@@ -12976,10 +15578,21 @@ spec:
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
-                                description: The name of the file certificate in the Secret.
+                                description: The name of the file certificate in the secret.
+                              pattern:
+                                type: string
+                                description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                            oneOf:
+                            - properties:
+                                certificate: {}
+                              required:
+                              - certificate
+                            - properties:
+                                pattern: {}
+                              required:
+                              - pattern
                             required:
                             - secretName
-                            - certificate
                           description: Trusted certificates for TLS connection.
                       description: TLS configuration for connecting MirrorMaker 2 connectors to a cluster.
                     authentication:
@@ -13001,26 +15614,48 @@ spec:
                         accessTokenIsJwt:
                           type: boolean
                           description: Configure whether access token should be treated as JWT. This should be set to `false` if the authorization server returns opaque tokens. Defaults to `true`.
+                        accessTokenLocation:
+                          type: string
+                          description: Path to the token file containing an access token to be used for authentication.
                         audience:
                           type: string
                           description: "OAuth audience to use when authenticating against the authorization server. Some authorization servers require the audience to be explicitly set. The possible values depend on how the authorization server is configured. By default, `audience` is not specified when performing the token endpoint request."
                         certificateAndKey:
                           type: object
                           properties:
-                            key:
-                              type: string
-                              description: The name of the private key in the Secret.
                             secretName:
                               type: string
                               description: The name of the Secret containing the certificate.
                             certificate:
                               type: string
                               description: The name of the file certificate in the Secret.
+                            key:
+                              type: string
+                              description: The name of the private key in the Secret.
+                          required:
+                          - secretName
+                          - certificate
+                          - key
+                          description: Reference to the `Secret` which holds the certificate and private key pair.
+                        clientAssertion:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                              description: The key under which the secret value is stored in the Kubernetes Secret.
+                            secretName:
+                              type: string
+                              description: The name of the Kubernetes Secret containing the secret value.
                           required:
                           - key
                           - secretName
-                          - certificate
-                          description: Reference to the `Secret` which holds the certificate and private key pair.
+                          description: Link to Kubernetes secret containing the client assertion which was manually configured for the client.
+                        clientAssertionLocation:
+                          type: string
+                          description: Path to the file containing the client assertion to be used for authentication.
+                        clientAssertionType:
+                          type: string
+                          description: "The client assertion type. If not set, and either `clientAssertion` or `clientAssertionLocation` is configured, this value defaults to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`."
                         clientId:
                           type: string
                           description: OAuth Client ID which the Kafka client can use to authenticate against the OAuth server and use the token endpoint URI.
@@ -13087,6 +15722,11 @@ spec:
                           - key
                           - secretName
                           description: Link to Kubernetes Secret containing the refresh token which can be used to obtain access token from the authorization server.
+                        saslExtensions:
+                          additionalProperties:
+                            type: string
+                          type: object
+                          description: SASL extensions parameters.
                         scope:
                           type: string
                           description: OAuth scope to use when authenticating against the authorization server. Some authorization servers require this to be set. The possible values depend on how authorization server is configured. By default `scope` is not specified when doing the token endpoint request.
@@ -13100,10 +15740,21 @@ spec:
                                 description: The name of the Secret containing the certificate.
                               certificate:
                                 type: string
-                                description: The name of the file certificate in the Secret.
+                                description: The name of the file certificate in the secret.
+                              pattern:
+                                type: string
+                                description: "Pattern for the certificate files in the secret. Use the link:https://en.wikipedia.org/wiki/Glob_(programming)[_glob syntax_] for the pattern. All files in the secret that match the pattern are used."
+                            oneOf:
+                            - properties:
+                                certificate: {}
+                              required:
+                              - certificate
+                            - properties:
+                                pattern: {}
+                              required:
+                              - pattern
                             required:
                             - secretName
-                            - certificate
                           description: Trusted certificates for TLS connection to the OAuth server.
                         tokenEndpointUri:
                           type: string
@@ -13155,7 +15806,7 @@ spec:
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                         state:
                           type: string
                           enum:
@@ -13173,6 +15824,30 @@ spec:
                               type: integer
                               description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
+                        listOffsets:
+                          type: object
+                          properties:
+                            toConfigMap:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              description: Reference to the ConfigMap where the list of offsets will be written to.
+                          required:
+                          - toConfigMap
+                          description: Configuration for listing offsets.
+                        alterOffsets:
+                          type: object
+                          properties:
+                            fromConfigMap:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              description: Reference to the ConfigMap where the new offsets are stored.
+                          required:
+                          - fromConfigMap
+                          description: Configuration for altering offsets.
                       description: The specification of the Kafka MirrorMaker 2 source connector.
                     heartbeatConnector:
                       type: object
@@ -13187,7 +15862,7 @@ spec:
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                         state:
                           type: string
                           enum:
@@ -13205,6 +15880,30 @@ spec:
                               type: integer
                               description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
+                        listOffsets:
+                          type: object
+                          properties:
+                            toConfigMap:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              description: Reference to the ConfigMap where the list of offsets will be written to.
+                          required:
+                          - toConfigMap
+                          description: Configuration for listing offsets.
+                        alterOffsets:
+                          type: object
+                          properties:
+                            fromConfigMap:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              description: Reference to the ConfigMap where the new offsets are stored.
+                          required:
+                          - fromConfigMap
+                          description: Configuration for altering offsets.
                       description: The specification of the Kafka MirrorMaker 2 heartbeat connector.
                     checkpointConnector:
                       type: object
@@ -13219,7 +15918,7 @@ spec:
                         config:
                           x-kubernetes-preserve-unknown-fields: true
                           type: object
-                          description: "The Kafka Connector configuration. The following properties cannot be set: connector.class, tasks.max."
+                          description: "The Kafka Connector configuration. The following properties cannot be set: name, connector.class, tasks.max."
                         state:
                           type: string
                           enum:
@@ -13237,6 +15936,30 @@ spec:
                               type: integer
                               description: "The maximum number of connector restarts that the operator will try. If the connector remains in a failed state after reaching this limit, it must be restarted manually by the user. Defaults to an unlimited number of restarts."
                           description: Automatic restart of connector and tasks configuration.
+                        listOffsets:
+                          type: object
+                          properties:
+                            toConfigMap:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              description: Reference to the ConfigMap where the list of offsets will be written to.
+                          required:
+                          - toConfigMap
+                          description: Configuration for listing offsets.
+                        alterOffsets:
+                          type: object
+                          properties:
+                            fromConfigMap:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                              description: Reference to the ConfigMap where the new offsets are stored.
+                          required:
+                          - fromConfigMap
+                          description: Configuration for altering offsets.
                       description: The specification of the Kafka MirrorMaker 2 checkpoint connector.
                     topicsPattern:
                       type: string
@@ -13537,6 +16260,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -14005,7 +16735,105 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                      volumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: Secret to use populate the volume.
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: ConfigMap to use to populate the volume.
+                            emptyDir:
+                              type: object
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  type: object
+                                  properties:
+                                    amount:
+                                      type: string
+                                    format:
+                                      type: string
+                              description: EmptyDir to use to populate the volume.
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: PersistentVolumeClaim object to use to populate the volume.
+                            csi:
+                              type: object
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              description: CSIVolumeSource object to use to populate the volume.
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              emptyDir: {}
+                              persistentVolumeClaim: {}
+                              csi: {}
+                        description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect `Pods`.
                   apiService:
                     type: object
@@ -14087,12 +16915,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -14146,6 +17023,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka Connect container.
                   initContainer:
                     type: object
@@ -14161,12 +17058,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -14220,6 +17166,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka init container.
                   podDisruptionBudget:
                     type: object
@@ -14307,6 +17273,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -14775,7 +17748,105 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                      volumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: Secret to use populate the volume.
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: ConfigMap to use to populate the volume.
+                            emptyDir:
+                              type: object
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  type: object
+                                  properties:
+                                    amount:
+                                      type: string
+                                    format:
+                                      type: string
+                              description: EmptyDir to use to populate the volume.
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: PersistentVolumeClaim object to use to populate the volume.
+                            csi:
+                              type: object
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              description: CSIVolumeSource object to use to populate the volume.
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              emptyDir: {}
+                              persistentVolumeClaim: {}
+                              csi: {}
+                        description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka Connect Build `Pods`. The build pod is used only on Kubernetes.
                   buildContainer:
                     type: object
@@ -14791,12 +17862,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -14850,6 +17970,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka Connect Build container. The build container is used only on Kubernetes.
                   buildConfig:
                     type: object
@@ -14908,7 +18048,7 @@ spec:
                             description: Annotations added to the Kubernetes resource.
                         description: Metadata applied to the resource.
                     description: Template for Secret of the Kafka Connect Cluster JMX authentication.
-                description: "Template for Kafka Connect and Kafka Mirror Maker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
+                description: "Template for Kafka Connect and Kafka MirrorMaker 2 resources. The template allows users to specify how the `Pods`, `Service`, and other services are generated."
               externalConfiguration:
                 type: object
                 properties:
@@ -14943,6 +18083,15 @@ spec:
                                 optional:
                                   type: boolean
                               description: Reference to a key in a ConfigMap.
+                          oneOf:
+                          - properties:
+                              secretKeyRef: {}
+                            required:
+                            - secretKeyRef
+                          - properties:
+                              configMapKeyRef: {}
+                            required:
+                            - configMapKeyRef
                           description: Value of the environment variable which will be passed to the Kafka Connect pods. It can be passed either as a reference to Secret or ConfigMap field. The field has to specify exactly one Secret or ConfigMap.
                       required:
                       - name
@@ -14998,6 +18147,15 @@ spec:
                             optional:
                               type: boolean
                           description: Reference to a key in a ConfigMap. Exactly one Secret or ConfigMap has to be specified.
+                      oneOf:
+                      - properties:
+                          secret: {}
+                        required:
+                        - secret
+                      - properties:
+                          configMap: {}
+                        required:
+                        - configMap
                       required:
                       - name
                     description: Makes data from a Secret or ConfigMap available in the Kafka Connect pods as volumes.
@@ -15112,29 +18270,13 @@ spec:
       description: The name of the Kafka cluster this resource rebalances
       jsonPath: .metadata.labels.strimzi\.io/cluster
       type: string
-    - name: PendingProposal
-      description: A proposal has been requested from Cruise Control
-      jsonPath: ".status.conditions[?(@.type==\"PendingProposal\")].status"
+    - name: Template
+      description: If this rebalance resource is a template
+      jsonPath: .metadata.annotations.strimzi\.io/rebalance-template
       type: string
-    - name: ProposalReady
-      description: A proposal is ready and waiting for approval
-      jsonPath: ".status.conditions[?(@.type==\"ProposalReady\")].status"
-      type: string
-    - name: Rebalancing
-      description: Cruise Control is doing the rebalance
-      jsonPath: ".status.conditions[?(@.type==\"Rebalancing\")].status"
-      type: string
-    - name: Ready
-      description: The rebalance is complete
-      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-      type: string
-    - name: NotReady
-      description: There is an error on the custom resource
-      jsonPath: ".status.conditions[?(@.type==\"NotReady\")].status"
-      type: string
-    - name: Stopped
-      description: Processing the proposal or running rebalancing was stopped
-      jsonPath: ".status.conditions[?(@.type==\"Stopped\")].status"
+    - name: Status
+      description: Status of the current rebalancing operation
+      jsonPath: ".status.conditions[*].type"
       type: string
     schema:
       openAPIV3Schema:
@@ -15157,7 +18299,8 @@ spec:
                 - full
                 - add-brokers
                 - remove-brokers
-                description: "Mode to run the rebalancing. The supported modes are `full`, `add-brokers`, `remove-brokers`.\nIf not specified, the `full` mode is used by default. \n\n* `full` mode runs the rebalancing across all the brokers in the cluster.\n* `add-brokers` mode can be used after scaling up the cluster to move some replicas to the newly added brokers.\n* `remove-brokers` mode can be used before scaling down the cluster to move replicas out of the brokers to be removed.\n"
+                - remove-disks
+                description: "Mode to run the rebalancing. The supported modes are `full`, `add-brokers`, `remove-brokers`.\nIf not specified, the `full` mode is used by default. \n\n* `full` mode runs the rebalancing across all the brokers in the cluster.\n* `add-brokers` mode can be used after scaling up the cluster to move some replicas to the newly added brokers.\n* `remove-brokers` mode can be used before scaling down the cluster to move replicas out of the brokers to be removed.\n* `remove-disks` mode can be used to move data across the volumes within the same broker\n."
               brokers:
                 type: array
                 items:
@@ -15198,6 +18341,22 @@ spec:
                 items:
                   type: string
                 description: "A list of strategy class names used to determine the execution order for the replica movements in the generated optimization proposal. By default BaseReplicaMovementStrategy is used, which will execute the replica movements in the order that they were generated."
+              moveReplicasOffVolumes:
+                type: array
+                minItems: 1
+                items:
+                  type: object
+                  properties:
+                    brokerId:
+                      type: integer
+                      description: ID of the broker that contains the disk from which you want to move the partition replicas.
+                    volumeIds:
+                      type: array
+                      minItems: 1
+                      items:
+                        type: integer
+                      description: IDs of the disks from which the partition replicas need to be moved.
+                description: List of brokers and their corresponding volumes from which replicas need to be moved.
             description: The specification of the Kafka rebalance.
           status:
             type: object
@@ -15276,6 +18435,10 @@ spec:
       description: Roles of the nodes in the pool
       jsonPath: .status.roles
       type: string
+    - name: NodeIds
+      description: Node IDs used by Kafka nodes in this pool
+      jsonPath: .status.nodeIds
+      type: string
     schema:
       openAPIV3Schema:
         type: object
@@ -15324,7 +18487,7 @@ spec:
                         broker:
                           type: integer
                           description: Id of the kafka broker (broker identifier).
-                    description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                    description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                   selector:
                     additionalProperties:
                       type: string
@@ -15375,7 +18538,7 @@ spec:
                               broker:
                                 type: integer
                                 description: Id of the kafka broker (broker identifier).
-                          description: Overrides for individual brokers. The `overrides` field allows to specify a different configuration for different brokers.
+                          description: Overrides for individual brokers. The `overrides` field allows you to specify a different configuration for different brokers.
                         selector:
                           additionalProperties:
                             type: string
@@ -15516,6 +18679,13 @@ spec:
                       securityContext:
                         type: object
                         properties:
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           fsGroup:
                             type: integer
                           fsGroupChangePolicy:
@@ -15984,7 +19154,105 @@ spec:
                       tmpDirSizeLimit:
                         type: string
                         pattern: "^([0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
-                        description: Defines the total amount (for example `1Gi`) of local storage required for temporary EmptyDir volume (`/tmp`). Default value is `5Mi`.
+                        description: "Defines the total amount of pod memory allocated for the temporary `EmptyDir` volume `/tmp`. Specify the allocation in memory units, for example, `100Mi` for 100 mebibytes. Default value is `5Mi`. The `/tmp` volume is backed by pod memory, not disk storage, so avoid setting a high value as it consumes pod memory resources."
+                      volumes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              description: Name to use for the volume. Required.
+                            secret:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                optional:
+                                  type: boolean
+                                secretName:
+                                  type: string
+                              description: Secret to use populate the volume.
+                            configMap:
+                              type: object
+                              properties:
+                                defaultMode:
+                                  type: integer
+                                items:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        type: integer
+                                      path:
+                                        type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              description: ConfigMap to use to populate the volume.
+                            emptyDir:
+                              type: object
+                              properties:
+                                medium:
+                                  type: string
+                                sizeLimit:
+                                  type: object
+                                  properties:
+                                    amount:
+                                      type: string
+                                    format:
+                                      type: string
+                              description: EmptyDir to use to populate the volume.
+                            persistentVolumeClaim:
+                              type: object
+                              properties:
+                                claimName:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                              description: PersistentVolumeClaim object to use to populate the volume.
+                            csi:
+                              type: object
+                              properties:
+                                driver:
+                                  type: string
+                                fsType:
+                                  type: string
+                                nodePublishSecretRef:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                readOnly:
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              description: CSIVolumeSource object to use to populate the volume.
+                          oneOf:
+                          - properties:
+                              secret: {}
+                              configMap: {}
+                              emptyDir: {}
+                              persistentVolumeClaim: {}
+                              csi: {}
+                        description: Additional volumes that can be mounted to the pod.
                     description: Template for Kafka `Pods`.
                   perPodService:
                     type: object
@@ -16072,12 +19340,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -16131,6 +19448,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka broker container.
                   initContainer:
                     type: object
@@ -16146,12 +19483,61 @@ spec:
                             value:
                               type: string
                               description: The environment variable value.
+                            valueFrom:
+                              type: object
+                              properties:
+                                secretKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a secret.
+                                configMapKeyRef:
+                                  type: object
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  description: Reference to a key in a config map.
+                              oneOf:
+                              - properties:
+                                  secretKeyRef: {}
+                                required:
+                                - secretKeyRef
+                              - properties:
+                                  configMapKeyRef: {}
+                                required:
+                                - configMapKeyRef
+                              description: Reference to the secret or config map property to which the environment variable is set.
+                          oneOf:
+                          - properties:
+                              value: {}
+                            required:
+                            - value
+                          - properties:
+                              valueFrom: {}
+                            required:
+                            - valueFrom
                         description: Environment variables which should be applied to the container.
                       securityContext:
                         type: object
                         properties:
                           allowPrivilegeEscalation:
                             type: boolean
+                          appArmorProfile:
+                            type: object
+                            properties:
+                              localhostProfile:
+                                type: string
+                              type:
+                                type: string
                           capabilities:
                             type: object
                             properties:
@@ -16205,6 +19591,26 @@ spec:
                               runAsUserName:
                                 type: string
                         description: Security context for the container.
+                      volumeMounts:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            mountPath:
+                              type: string
+                            mountPropagation:
+                              type: string
+                            name:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            recursiveReadOnly:
+                              type: string
+                            subPath:
+                              type: string
+                            subPathExpr:
+                              type: string
+                        description: Additional volume mounts which should be applied to the container.
                     description: Template for the Kafka init container.
                 description: Template for pool resources. The template allows users to specify how the resources belonging to this pool are generated.
             required:

--- a/kubernetes/cray-kafka-operator/templates/01-crd-configmap.yaml
+++ b/kubernetes/cray-kafka-operator/templates/01-crd-configmap.yaml
@@ -1,7 +1,7 @@
 {{- /*
 MIT License
 
-(C) Copyright 2024 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -30,5 +30,5 @@ metadata:
     helm.sh/hook: pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 data:
-  strimzi-crds-0.41.0.yaml: |-
-    {{- .Files.Get "files/strimzi-crds-0.41.0.yaml" | nindent 4 }}
+  strimzi-crds-0.45.0.yaml: |-
+    {{- .Files.Get "files/strimzi-crds-0.45.0.yaml" | nindent 4 }}

--- a/kubernetes/cray-kafka-operator/templates/03-update-crd-job.yaml
+++ b/kubernetes/cray-kafka-operator/templates/03-update-crd-job.yaml
@@ -1,7 +1,7 @@
 {{- /*
 MIT License
 
-(C) Copyright 2024 Hewlett Packard Enterprise Development LP
+(C) Copyright 2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -56,4 +56,4 @@ spec:
             - '/bin/sh'
           args:
             - "-c"
-            - kubectl apply -f /tmp/strimzi-crds-0.41.0.yaml
+            - kubectl apply -f /tmp/strimzi-crds-0.45.0.yaml

--- a/kubernetes/cray-kafka-operator/values.yaml
+++ b/kubernetes/cray-kafka-operator/values.yaml
@@ -10,7 +10,7 @@ strimzi-kafka-operator:
     registry: artifactory.algol60.net
     repository: csm-docker/stable/quay.io/strimzi
     name: operator
-    tag: 0.41.0
+    tag: 0.45.0
     imagePullPolicy: IfNotPresent
 
   zookeeper:
@@ -18,79 +18,79 @@ strimzi-kafka-operator:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.41.0-noJSM-chainsaw
+      tagPrefix: 0.45.0
   kafka:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.41.0-noJSM-chainsaw
+      tagPrefix: 0.45.0
   kafkaConnect:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.41.0-noJSM-chainsaw
+      tagPrefix: 0.45.0
   kafkaConnects2i:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.41.0-noJSM-chainsaw
+      tagPrefix: 0.45.0
   topicOperator:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: operator
-      tag: 0.41.0
+      tag: 0.45.0
   userOperator:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: operator
-      tag: 0.41.0
+      tag: 0.45.0
   kafkaInit:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: operator
-      tag: 0.41.0
+      tag: 0.45.0
   tlsSidecarZookeeper:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.41.0-noJSM-chainsaw
+      tagPrefix: 0.45.0
   tlsSidecarKafka:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.41.0-noJSM-chainsaw
+      tagPrefix: 0.45.0
   tlsSidecarEntityOperator:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.41.0-noJSM-chainsaw
+      tagPrefix: 0.45.0
   kafkaMirrorMaker:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.41.0-noJSM-chainsaw
+      tagPrefix: 0.45.0
   kafkaBridge:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka-bridge
-      tag: 0.28.0
+      tag: 0.31.1
   kafkaExporter:
     image:
       registry: artifactory.algol60.net
       repository: csm-docker/stable/quay.io/strimzi
       name: kafka
-      tagPrefix: 0.41.0-noJSM-chainsaw
+      tagPrefix: 0.45.0
 
   # Increase resources.limits.cpu to 8 to reduce cpu throttling
   resources:


### PR DESCRIPTION
## Summary and Scope

Upgrade kafka-operator to version 0.45.0

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Related to [CASMPET-7382](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7382)
* Image PR: https://github.com/Cray-HPE/container-images/pull/666
* `shared-kafka` PR: https://github.com/Cray-HPE/cray-shared-kafka/pull/13

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Previous image:
```
# kubectl describe deployment cray-shared-kafka-entity-operator -n services  | grep Image
    Image:      artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.41.0
    Image:      artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.41.0
# kubectl get crds | grep kafka.strimzi.io
kafkabridges.kafka.strimzi.io                         2025-02-06T21:00:26Z
kafkaconnectors.kafka.strimzi.io                      2025-02-06T21:00:26Z
kafkaconnects.kafka.strimzi.io                        2025-02-06T21:00:26Z
kafkamirrormaker2s.kafka.strimzi.io                   2025-02-06T21:00:26Z
kafkamirrormakers.kafka.strimzi.io                    2025-02-06T21:00:26Z
kafkanodepools.kafka.strimzi.io                       2025-02-06T21:00:26Z
kafkarebalances.kafka.strimzi.io                      2025-02-06T21:00:26Z
kafkas.kafka.strimzi.io                               2025-02-06T21:00:25Z
kafkatopics.kafka.strimzi.io                          2025-02-06T21:00:26Z
kafkausers.kafka.strimzi.io                           2025-02-06T21:00:26Z
```

All pods updated and using new images:
```
# kubectl get pods -A | grep strimzi
operators        strimzi-cluster-operator-6986698dc6-2ms4n                         1/1     Running            0                3m17s
# kubectl describe pod strimzi-cluster-operator-6986698dc6-2ms4n -n operators | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
# kubectl get pods -A | grep kafka
services         cray-shared-kafka-entity-operator-6fdb8685b6-kjkfd                2/2     Running            0                21s
services         cray-shared-kafka-kafka-0                                         1/1     Running            0                108s
services         cray-shared-kafka-kafka-1                                         1/1     Running            0                78s
services         cray-shared-kafka-kafka-2                                         1/1     Running            0                51s
services         cray-shared-kafka-zookeeper-0                                     1/1     Running            0                2m20s
services         cray-shared-kafka-zookeeper-1                                     1/1     Running            0                3m36s
services         cray-shared-kafka-zookeeper-2                                     1/1     Running            0                3m2s
# kubectl describe pod -n services cray-shared-kafka-entity-operator-6fdb8685b6-kjkfd | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
# kubectl describe pod cray-shared-kafka-kafka-0 -n services | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
# kubectl describe pod cray-shared-kafka-zookeeper-0 -n services | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
```

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

